### PR TITLE
fix for 6.17

### DIFF
--- a/drm_internal.h
+++ b/drm_internal.h
@@ -81,9 +81,6 @@ void drm_prime_destroy_file_private(struct drm_prime_file_private *prime_fpriv);
 void drm_prime_remove_buf_handle(struct drm_prime_file_private *prime_fpriv,
 				 uint32_t handle);
 
-/* drm_drv.c */
-struct drm_minor *drm_minor_acquire(unsigned int minor_id);
-void drm_minor_release(struct drm_minor *minor);
 
 /* drm_managed.c */
 void drm_managed_release(struct drm_device *dev);

--- a/gna_device.c
+++ b/gna_device.c
@@ -190,7 +190,6 @@ static const struct drm_driver gna_drm_driver = {
 
 	.name = DRIVER_NAME,
 	.desc = DRIVER_DESC,
-	.date = DRIVER_DATE,
 	.major = DRIVER_MAJOR,
 	.minor = DRIVER_MINOR,
 	.patchlevel = DRIVER_PATCHLEVEL,

--- a/intel-gna-kmod.spec
+++ b/intel-gna-kmod.spec
@@ -133,7 +133,8 @@ install -m 0644 include/uapi/drm/gna_drm.h %{buildroot}/%{_includedir}/drm/gna_d
 
 for kernel_version in %{?kernel_versions}; do
     mkdir -p ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}
-    make -C "${kernel_version##*___}" M=${PWD}/_kmod_build_${kernel_version%%___*} INSTALL_MOD_PATH=${RPM_BUILD_ROOT} INSTALL_MOD_DIR=%{kmodinstdir_postfix} modules_install
+    # FIX: Added '/../' to the M= path below so it finds the sibling build directory
+    make -C "${kernel_version##*___}" M=${PWD}/../_kmod_build_${kernel_version%%___*} INSTALL_MOD_PATH=${RPM_BUILD_ROOT} INSTALL_MOD_DIR=%{kmodinstdir_postfix} modules_install
     install -m 0644 ${PWD}/../_kmod_build_${kernel_version%%___*}/gna.ko ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/gna.ko
     # DEPMOD creates a bunch of files for us, we'd rather not bother with them
     rm ${RPM_BUILD_ROOT}%{kmodinstdir_prefix}/${kernel_version%%___*}/modules.*


### PR DESCRIPTION
This change will ensure it’s built for kernel 6.17 on Fedora 43.